### PR TITLE
feat: Increase the adaptive size of the depot recognize view

### DIFF
--- a/src/MaaWpfGui/Views/UI/RecognizerView.xaml
+++ b/src/MaaWpfGui/Views/UI/RecognizerView.xaml
@@ -314,21 +314,27 @@
                 </StackPanel>
                 <DataGrid
                     Grid.Row="1"
-                    Width="680"
-                    HorizontalAlignment="Center"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
                     AutoGenerateColumns="False"
                     HeadersVisibility="None"
                     IsReadOnly="True"
                     ItemsSource="{Binding DepotResult}"
-                    ScrollViewer.CanContentScroll="True"
+                    ScrollViewer.CanContentScroll="False"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <DataGrid.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <WrapPanel HorizontalAlignment="Center" />
+                            <!--<WrapPanel
+                                HorizontalAlignment="Center"
+                                ItemHeight="80"
+                                ItemWidth="300"
+                                Orientation="Horizontal" />-->
+                            <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal" />
                         </ItemsPanelTemplate>
                     </DataGrid.ItemsPanel>
                     <DataGrid.Columns>
-                        <DataGridTemplateColumn>
+                        <DataGridTemplateColumn Width="100">
+
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Image
@@ -338,8 +344,16 @@
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
-                        <DataGridTextColumn Binding="{Binding Name}" Header="Name" />
-                        <DataGridTextColumn Binding="{Binding Count}" Header="Count" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding Name}"
+                            Header="Name" />
+
+                        <DataGridTextColumn
+                            Width="60"
+                            Binding="{Binding Count}"
+                            Header="Count" />
+
                     </DataGrid.Columns>
                 </DataGrid>
                 <StackPanel


### PR DESCRIPTION
Increase the adaptive size of the warehouse detection window
- Target
  - Enlarge the display window to see more repository content at once
- Add content
  - DataGrid adaptively resizes the window view and dynamically adjusts the number of item columns

Screenshot example
- New
![image](https://github.com/user-attachments/assets/fe7a5265-84ca-4ed7-9225-91a896761334)
- Old
![image](https://github.com/user-attachments/assets/4c47a0e4-d4e3-4f7b-95e9-733fdc3d0bde)
